### PR TITLE
config: put username/password in ~/.config

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,11 @@
 This script exports EliteHRV raw data to a .json file:
 
-    ./elitehrv-sync.py EMAIL PASSWORD hrv.json
+    ./elitehrv-sync.py hrv.json
+
+Configure your username (email) and password in ~/.config/elitehrv.conf:
+
+    username=your-email@here
+    password=your-password-here
 
 To analyze this with PhysioNet's hrv toolkit, fetch two more git trees
 into this tree:

--- a/elitehrv-sync.py
+++ b/elitehrv-sync.py
@@ -63,15 +63,23 @@ def merge(master, latest, complain=False):
             else:
                 master[key] = latest[key]
 
-try:
-    email = sys.argv[1]
-    password = sys.argv[2]
-    datafile = None
-    if len(sys.argv) > 3:
-        datafile = sys.argv[3]
-except:
-    print("Usage: %s EMAIL PASSWORD [DATA.json]\n", sys.argv[0])
-    sys.exit(1)
+conffile = open(os.path.expanduser("~/.config/elitehrv.conf"))
+for line in conffile:
+    line = line.strip()
+    name, value = line.split('=')
+    if name == "username":
+        email = value
+    elif name == "password":
+        password = value
+    else:
+        raise ValueError("Unknown configuration option '%s'" % (name))
+
+datafile = None
+if len(sys.argv) > 1:
+    if sys.argv[1] in ["-h", "--help"]:
+        print("Usage: %s [DATA.json]\n", sys.argv[0])
+        sys.exit(1)
+    datafile = sys.argv[1]
 
 if datafile:
     try:


### PR DESCRIPTION
Passwords shouldn't be on the command line.

Signed-off-by: Kees Cook kees@outflux.net
